### PR TITLE
Adding additional mirror to maven.json

### DIFF
--- a/bucket/maven.json
+++ b/bucket/maven.json
@@ -2,7 +2,10 @@
     "homepage": "https://maven.apache.org/",
     "version": "3.5.0",
     "license": "Apache 2.0",
-    "url": "https://archive.apache.org/dist/maven/maven-3/3.5.0/binaries/apache-maven-3.5.0-bin.zip",
+    "url": [
+        "https://archive.apache.org/dist/maven/maven-3/3.5.0/binaries/apache-maven-3.5.0-bin.zip",
+        "https://mirrors.koehn.com/apache/maven/maven-3/3.5.0/binaries/apache-maven-3.5.0-bin.zip"
+    ],
     "hash": "sha1:886393e7031d42c412a077c240af73d75e671d62",
     "extract_dir": "apache-maven-3.5.0",
     "env_add_path": "bin",


### PR DESCRIPTION
In some locations, the main archive mirror is not available. Listing the next most popular one at the time of this update